### PR TITLE
add check for undefined behaviour of HRTI E without M

### DIFF
--- a/mycology.b98
+++ b/mycology.b98
@@ -234,9 +234,9 @@ n                >na"stcelfer G :DAB";   >0a"detcelfer TTM :DAB"a               
 > ay     v     >#^G0" sa ytiralunarg kcolc sevig G :FEDNU">:#,_$.0a"sdnocesorcim">:#,_$#vT0a"M erofeb dellac nehw detcelfer evah dluohs T :DAB"^$
  ^"HRTI"0<             v_v#!p00:-1<*ff       .$_,#! #:<"UNDEF: T after M pushed "0T^#  ;>  a"M erofeb dellac nehw detcelfer T :DOOG">:#,_#^S0" dehsup S :FEDNU">:#,_$.a,#^M#;<
 v                      >;>yynyn00g^;  #vT 0" dehsup ,sy 576 retfa ,T dnoces a dna">:#,_$.a,#vE #vT0a"tcelfer t'nseod TE :DAB"                   ^
-v )g22g33,a <                  < v"di";>n^;"d not reflect"Ev#$_,#! #:<"GOOD: ET reflected"a0># #<0a"stcelfer E :DAB"                            ^
-         >;#"UNDEF: E without M "<;>:#,_$v     ;"reflected"<     v
-                               ^         <                     H >0a"tsaehtron seog v< >H retfa ^ :DAB"v             vv  $_,#! #:<H"GOOD: |_ seem to work in hovermode"av
+v )g22g33,a <        <         v"did ";>n^;"not reflect"a0Ev#$_,#! #:<"GOOD: ET reflected"a0># #<0a"stcelfer E :DAB"                            ^
+         >;#"UNDEF: E without M "<;>:#,_$v   ;"reflected"a0<     v
+                     ^        ;> ^;      <                     H >0a"tsaehtron seog v< >H retfa ^ :DAB"v             vv  $_,#! #:<H"GOOD: |_ seem to work in hovermode"av
 n                                                            >0a"pu thgiarts seog v< >H retfa ^ :DAB"  v            _0a"thgir seog _0H :DAB"      v"BAD: H1_ goes left"a0_  >"domh"v
 > ay     vvv;>#v#vH   >v   v<     #; #<                     vHH             v   "BAD: H1| goes straight up"a0      <0 ' " v>#                 #<v#                       <  ev"itc"<
  ^"MODE"0<>      >0a"stcelfer H :DAB" ^              >:#,_$vH^a"edomrevoh ni krow ot mees v^<> :DOOG" H >:#,_ H |  H< :  ^;^"BAD: S reflects"a0<>:#,_$v;               1^   '>"ws "v

--- a/mycology.b98
+++ b/mycology.b98
@@ -234,9 +234,9 @@ n                >na"stcelfer G :DAB";   >0a"detcelfer TTM :DAB"a               
 > ay     v     >#^G0" sa ytiralunarg kcolc sevig G :FEDNU">:#,_$.0a"sdnocesorcim">:#,_$#vT0a"M erofeb dellac nehw detcelfer evah dluohs T :DAB"^$
  ^"HRTI"0<             v_v#!p00:-1<*ff       .$_,#! #:<"UNDEF: T after M pushed "0T^#  ;>  a"M erofeb dellac nehw detcelfer T :DOOG">:#,_#^S0" dehsup S :FEDNU">:#,_$.a,#^M#;<
 v                      >;>yynyn00g^;  #vT 0" dehsup ,sy 576 retfa ,T dnoces a dna">:#,_$.a,#vE #vT0a"tcelfer t'nseod TE :DAB"                   ^
-v )g22g33,a <                         ;>n^;                  $_,#! #:<"GOOD: ET reflected"a0># #<0a"stcelfer E :DAB"                            ^
-                                                                 v
-                                                               H >0a"tsaehtron seog v< >H retfa ^ :DAB"v             vv  $_,#! #:<H"GOOD: |_ seem to work in hovermode"av
+v )g22g33,a <                  < v"di";>n^;"d not reflect"Ev#$_,#! #:<"GOOD: ET reflected"a0># #<0a"stcelfer E :DAB"                            ^
+         >;#"UNDEF: E without M "<;>:#,_$v     ;"reflected"<     v
+                               ^         <                     H >0a"tsaehtron seog v< >H retfa ^ :DAB"v             vv  $_,#! #:<H"GOOD: |_ seem to work in hovermode"av
 n                                                            >0a"pu thgiarts seog v< >H retfa ^ :DAB"  v            _0a"thgir seog _0H :DAB"      v"BAD: H1_ goes left"a0_  >"domh"v
 > ay     vvv;>#v#vH   >v   v<     #; #<                     vHH             v   "BAD: H1| goes straight up"a0      <0 ' " v>#                 #<v#                       <  ev"itc"<
  ^"MODE"0<>      >0a"stcelfer H :DAB" ^              >:#,_$vH^a"edomrevoh ni krow ot mees v^<> :DOOG" H >:#,_ H |  H< :  ^;^"BAD: S reflects"a0<>:#,_$v;               1^   '>"ws "v


### PR DESCRIPTION
Add a test for the undefined behaviour of the "erase mark" of the HRTI fingerprint. More information at catseye/Funge-98#13.

The new check runs directly after the `ET` reflection check, and may print one of the two following values depending on whichever happens:
`UNDEF: E without M did not reflect`
`UNDEF: E without M reflected`

Given that `E` was already executed beforehand unconditionally in the ET check, a mark definitely does not exist when this check executes.
This new addition was verified working using rcfunge2 (handprint 0x52435355 "RCSU", version 20300), and on JFunge (handprint 0xfa15e9a7, version 65537 "1.0.1"), both go through without reflection, and the addition hasn't broken any existing checks inside mycology.